### PR TITLE
Fix crash on close: reading maxErrorCount after Qt widget teardown

### DIFF
--- a/esibd/core.py
+++ b/esibd/core.py
@@ -5711,8 +5711,16 @@ class TimeoutLock:
             finally:
                 if result and not already_acquired:
                     self._lock.release()
-                if ((self.lockParent.errorCount == self.lockParent.maxErrorCount or self.lockParent.errorCount > 2 * self.lockParent.maxErrorCount) and
-                    isinstance(self.lockParent, DeviceController)):
+                try:
+                    exceeded = (self.lockParent.errorCount == self.lockParent.maxErrorCount
+                                or self.lockParent.errorCount > 2 * self.lockParent.maxErrorCount)
+                except RuntimeError:
+                    # maxErrorCount is a Setting backed by a Qt spin widget; reading it
+                    # after that widget was deleted during GUI teardown raises
+                    # RuntimeError and would otherwise crash closeGUI. During teardown the
+                    # close-on-errors check is irrelevant, so treat it as not exceeded.
+                    exceeded = False
+                if exceeded and isinstance(self.lockParent, DeviceController):
                     # only call closeCommunication when equal to maxErrorCount, Otherwise errors during closeCommunication could cause recursion.
                     self.print(f'Closing communication of {self.lockParent.name} after more than {self.lockParent.errorCount} consecutive errors.', flag=PRINT.ERROR)  # {e}
                     if not self.lockParent.closing:  # avoid recursion if lock cannot be acquired while closing


### PR DESCRIPTION
## Problem

Closing ESIBD Explorer can crash in `Lock.acquire_timeout.__exit__` with:

```
File "esibd\core.py", line 5714, in acquire_timeout   # __exit__ finally
    if ((self.lockParent.errorCount == self.lockParent.maxErrorCount or ...) and
                       ^^^^^^^^^^^^^^^^^^^^^
File "esibd\const.py", line 350, in getter
    return settingsMgr.settings[name].value
File "esibd\core.py", line 1566, in value
    value = self.spin.value()
RuntimeError: wrapped C/C++ object of type LabviewSpinBox has been deleted
```

This surfaces as `Could not close plugin <X>: Traceback ...` in the log on shutdown (reproduced with my plugins).

## Root cause (examined with GLM 5.2)

`Lock.acquire_timeout.__exit__` evaluates `lockParent.maxErrorCount` on **every** lock release. `maxErrorCount` is a `Setting` (`plugins.py`, `attr='maxErrorCount'`, `PARAMETERTYPE.INT`) whose `value` getter reads the backing Qt spin widget (`core.py:1566 self.spin.value()`).

During `closeGUI` (e.g. `toggleLiveDisplay` inside `closePlugins`) the Qt widget is destroyed before the `acquire_timeout` context exits, so reading `maxErrorCount` raises `RuntimeError: wrapped C/C++ object ... has been deleted`, which propagates out of `__exit__` and aborts the close.

## Fix

Guard the error-count condition in `acquire_timeout.__exit__` so a `RuntimeError` from a deleted setting widget is treated as "not exceeded" instead of crashing teardown. The close-on-errors check is irrelevant while the GUI is already being torn down, so skipping it is safe.

The guard covers every `acquire_timeout`-based close path (all go through this `__exit__`), not just `toggleLiveDisplay`.

## Notes / possible follow-up

The deeper root cause is that `Setting.value` reads Qt widgets with no tolerance for a deleted underlying C++ object. A broader hardening (guard the widget reads in `Setting.value`, returning the last/default value) would make any setting read during teardown safe, but it touches a hot path and changes return semantics, so I kept this PR minimal and targeted at the reported crash. Happy to follow up with that if desired.

Verified with `py_compile`; no hardware behavior change (the change only affects the already-closing teardown path).